### PR TITLE
Bind to LDAP server synchronously.

### DIFF
--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -102,7 +102,7 @@ def bind():
 
   ldapobject = ldap.initialize(url)
 
-  ldapobject.bind(bind_dn, bind_password)
+  ldapobject.bind_s(bind_dn, bind_password)
 
   if verbose:
     print("Successfully bound to %s..." % url)


### PR DESCRIPTION
Similar to https://bitbucket.org/whitlockjc/jw-tools/issue/8/bind-returns-before-binding-operation-is

Error message:

```
Successfully bound to ldap://foo
Error performing search: {'info': '00002024: LdapErr: DSID-0C060598, comment: No other operations may be performed on the connection while a bind is outstanding., data 0, v1db1', 'desc': 'Server is busy'}
```
