### PR TITLE
Add new capability to retrieve known groups.

### DIFF
--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -142,14 +142,15 @@ def get_groups(ldapobject):
 
   groups = []
   for group_dn in group_dns:
-    result_set = get_ldap_search_resultset(group_dn, group_query, ldapobject, ldap.SCOPE_BASE)
-    if result_set:      
+    try:
+      result_set = get_ldap_search_resultset(group_dn, group_query, ldapobject, ldap.SCOPE_BASE)
       for i in range(len(result_set)):
         for entry in result_set[i]:
           groups.append(entry)
-    else:
+    except ldap.NO_SUCH_OBJECT, e:
       if verbose:
         print("Couldn't find a group with DN %s." % group_dn)
+      raise e
 
   if verbose:
     print("%d groups found." % len(groups))

--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -162,7 +162,7 @@ def get_groups(ldapobject):
 def get_ldap_search_resultset(base_dn, group_query, ldapobject, scope=ldap.SCOPE_SUBTREE):
   """This function will return a query result set."""
   result_set = []
-  result_id = ldapobject.search(base_dn, ldap.SCOPE_SUBTREE, group_query)
+  result_id = ldapobject.search(base_dn, scope, group_query)
 
   while 1:
     result_type, result_data = ldapobject.result(result_id, 0)


### PR DESCRIPTION
## Use case

I have an LDAP server that contains a lot of LDAP groups. Using the existing mechanism, the script will retrieve all of the existing groups and put in the authz file regardless on whether the groups are actually used for authorization or not. The performance is also very slow.

Setting the --group-query to search for samAccountName doesn't work as I need the --follow-groups to work. When a sub group is found, it will not be detected as a group as the filter applied is the samAccountName. 
## New option

What I have introduced is a new option --known-group-dn. You can specify the full group DN directly, hence it won't be searching for groups in the entire LDAP server. When this option is used, --group-query will be ignored.
## How to use

```
python sync_ldap_groups_to_svn_authz.py -f \
-k CN=Release Managers,OU=Groups,DC=subversion,DC=thoughtspark,DC=org \
-k CN=Developers,OU=Groups,DC=subversion,DC=thoughtspark,DC=org
... other required options
```

I'm open for feedback shall there be a better alternatives or code improvement is required.
