### PR TITLE
Better management of output messages, better content generation

### DIFF
--- a/README
+++ b/README
@@ -3,13 +3,21 @@
 ================================================================================
 Author: Jeremy Whitlock <jwhitlock@collab.net>, Christophe Drevet <dr4ke@dr4ke.net>
 License: GPLv3
-Version: 1.1.0
+Version: 1.3.0
 Website: http://www.thoughtspark.org/
 Support: Feel free to reach out to me for bugs, suggestions, etc.
 ================================================================================
 
 Change Log
 --------------------------------------------------------------------------------
+2015-08-24 (version 1.3.0):
+- Better management of outputs: all errors/warnings are directed to stderr, no information are provided if stdout is the authz destination file.
+- New parameter to be verbose only for errors/warnings.
+- Exit with error code 1 when no group is found.
+2015-05-12 (version 1.2.0):
+- Add new capability to retrieve known groups.
+- Fix empty user name when subgroup not in search scope.
+- Bind to LDAP server synchronously.
 2010-05-28 (version 1.1.0):
 - fix 'invalid cross-device link' error
 - handle TypeError when group not in search scope
@@ -113,6 +121,9 @@ the script, just to get our bearings:
                           The path to the authz file to update/create
     -f, --follow-groups   Follow sub-groups
     -q, --quiet           Suppress logging information
+    -v, --verbose-if-error
+                          Be verbose only for errors or warnings. This option is
+                          active only with -q.
 
 Anything that has a "[Default:" string in its corresponding documentation is
 "optional" and can usually be omitted when running against most directory

--- a/README
+++ b/README
@@ -10,22 +10,24 @@ Support: Feel free to reach out to me for bugs, suggestions, etc.
 
 Change Log
 --------------------------------------------------------------------------------
-2015-08-24 (version 1.3.0):
-- Better management of outputs: all errors/warnings are directed to stderr, no information are provided if stdout is the authz destination file.
-- New parameter to be verbose only for errors/warnings.
-- Exit with error code 1 when no group is found.
+2015-08-25 (version 1.3.0):
+ - Better management of outputs: all errors/warnings are directed to stderr; info messages are given to stdout if an authz destination file is provided and are redirected to stderr otherwise.
+ - New parameter -v to distinguish warning/error and info verbosity (-v enables info logs; -q disables warning/error logs).
+ - Exit with error code 1 when no group is found.
 2015-05-12 (version 1.2.0):
-- Add new capability to retrieve known groups.
-- Fix empty user name when subgroup not in search scope.
-- Bind to LDAP server synchronously.
+ - Add new capability to retrieve known groups.
+ - Fix empty user name when subgroup not in search scope.
+ - Bind to LDAP server synchronously.
 2010-05-28 (version 1.1.0):
-- fix 'invalid cross-device link' error
-- handle TypeError when group not in search scope
-- print a warning when a sub group is not in search scope
-- add an option to follow sub groups to include all user members recursively (avoids previous warnings)
-- print group processing progress in verbose mode (like : +..++.-.--)
-2009-01-22 - There was a bug when you didn't specify the -z flag and when the query returned no groups. Version 1.0.1 has been produced as a result.
-2009-04-15 - There was a bug with nested groups.  Version 1.0.2 has been produced as a result.
+ - fix 'invalid cross-device link' error
+ - handle TypeError when group not in search scope
+ - print a warning when a sub group is not in search scope
+ - add an option to follow sub groups to include all user members recursively (avoids previous warnings)
+ - print group processing progress in verbose mode (like : +..++.-.--)
+2009-01-22:
+ There was a bug when you didn't specify the -z flag and when the query returned no groups. Version 1.0.1 has been produced as a result.
+2009-04-15:
+ There was a bug with nested groups.  Version 1.0.2 has been produced as a result.
 
 Background
 --------------------------------------------------------------------------------
@@ -121,9 +123,7 @@ the script, just to get our bearings:
                           The path to the authz file to update/create
     -f, --follow-groups   Follow sub-groups
     -q, --quiet           Suppress logging information
-    -v, --verbose-if-error
-                          Be verbose only for errors or warnings. This option is
-                          active only with -q.
+    -v, --verbose         Give more details during the execution. Overrides -q
 
 Anything that has a "[Default:" string in its corresponding documentation is
 "optional" and can usually be omitted when running against most directory

--- a/README
+++ b/README
@@ -1,7 +1,10 @@
 ================================================================================
 =========        LDAP Groups to Subversion Authz Groups Bridge        ==========
 ================================================================================
-Author: Jeremy Whitlock <jwhitlock@collab.net>, Christophe Drevet <dr4ke@dr4ke.net>
+Author: Jeremy Whitlock <jwhitlock@collab.net>,
+        Christophe Drevet <dr4ke@dr4ke.net>,
+        Wisen Tanasa
+        Justin MASSIOT
 License: GPLv3
 Version: 1.3.0
 Website: http://www.thoughtspark.org/
@@ -15,6 +18,10 @@ Change Log
  - New parameter -v to distinguish warning/error and info verbosity (-v enables info logs; -q disables warning/error logs).
  - Exit with error code 1 when no group is found.
  - Hard-coded parameters at the top of the script are now optional.
+ - New parameter -n to keep exact LDAP group names. For example, "my-group" is
+   no longer replaced by "mygroup".
+ - All text found "around" the auto-generated groups are now restored at the right place.
+   You can define supergroups from LDAP groups safely.
 2015-05-12 (version 1.2.0):
  - Add new capability to retrieve known groups.
  - Fix empty user name when subgroup not in search scope.
@@ -47,15 +54,17 @@ shortcomings of such a configuration.
 The Problem
 --------------------------------------------------------------------------------
 Subversion's authz architecture requires your group definitions to be defined
-within the authz file.  Subversion's authz architecture is also unaware of
+within the authz file (not true any more as of Subversion 1.8: see the
+"groups-db" option).  Subversion's authz architecture is also unaware of
 third-party data stores for users/groups.  This means that if you do not define
 your group within the authz file, Subversion will not know whether a user is a
 member of said group and will ultimately tell you that you do not have access
 to a resource.  That being said, the current problem is that with this server
 configuration, either you cannot harness group models defined in your directory
-server or you have to manually synchronize your group models from your
-directory server to Subversion's authz file.  There are many downsides to doing
-things this way:
+server or you have to manually synchronize your group models from your directory
+server to Subversion's authz file.
+There are many downsides to doing things
+this way:
 
   * It's time consuming
   * It's easy to forget that changes have been made and need to be mirrored
@@ -141,6 +150,9 @@ the script, just to get our bearings:
     -z AUTHZ_PATH, --authz-path=AUTHZ_PATH
                           The fully-qualified path to the authz file to be
                           updated/created.
+    -n, --keep-names      Keep the exact LDAP group names without alteration.
+                          Useful if your group names contain non-word
+                          characters, i.e. not in [A-Za-z0-9_].
     -q, --quiet           Do not show logging information, except exit messages.
     -v, --verbose         Give more details during the execution. Overrides -q .
 
@@ -168,14 +180,14 @@ Let's pretend that I have a directory structure like this:
 This will help showcase how the "LDAP Groups to Subversion Authz Groups
 Bridge" handles this situation.)  I now want to run the script:
 
-  python sync_ldap_groups_to_svn_authz.py \
+  python sync_ldap_groups_to_svn_authz.py -v \
     -d "CN=Jeremy Whitlock,OU=Users,DC=subversion,DC=thoughtspark,DC=org" \
     -l "ldap://localhost:389" \
     -b "DC=subversion,DC=thoughtspark,DC=org" > svn_auth.txt
 
 You'll notice I didn't specify a password.  In this event, the script will
 prompt you, securely, for a password.  After the script runs, as long as you
-didn't run with the "-q" flag, you should see output like this:
+run with the "-v" flag, you should see output like this:
 
   Successfully bound to ldap://localhost:389
   4 groups found.
@@ -202,8 +214,7 @@ the message along side the warning to see why.)  So what does the file look like
 
   ### End generated content: LDAP Groups to Subversion Authz Groups Bridge ###
 
-Here is a list of features, or things to realize, based on the output of this
-script:
+Here is a list of features based on the output of this script:
 
   * The "[groups]" section is created but only if necessary
   * All generated content is within known "markers" for loss-less regeneration

--- a/README
+++ b/README
@@ -14,6 +14,7 @@ Change Log
  - Better management of outputs: all errors/warnings are directed to stderr; info messages are given to stdout if an authz destination file is provided and are redirected to stderr otherwise.
  - New parameter -v to distinguish warning/error and info verbosity (-v enables info logs; -q disables warning/error logs).
  - Exit with error code 1 when no group is found.
+ - Hard-coded parameters at the top of the script are now optional.
 2015-05-12 (version 1.2.0):
  - Add new capability to retrieve known groups.
  - Fix empty user name when subgroup not in search scope.
@@ -100,30 +101,48 @@ the script, just to get our bearings:
   Options:
     -h, --help            show this help message and exit
     -d BIND_DN, --bind-dn=BIND_DN
-                          The DN of the user to bind to the directory with
+                          The Distinguished Name (DN) used to bind to the
+                          directory with. [Example: CN=Jeremy Whitlock,OU=Users,
+                          DC=subversion,DC=thoughtspark,DC=org]
     -p BIND_PASSWORD, --bind-password=BIND_PASSWORD
                           The password for the user specified with the --bind-dn
-    -l URL, --url=URL     The url (scheme://hostname:port) for the directory
-                          server
+                          . [Example: pa55w0rd]
+    -l URL, --url=URL     The fully-qualified URL (scheme://hostname:port) to
+                          the directory server. [Example: ldap://localhost:389]
     -b BASE_DN, --base-dn=BASE_DN
-                          The DN at which to perform the recursive search
+                          The Distinguished Name (DN) at which the recursive
+                          group search will start. [Example:
+                          DC=subversion,DC=thoughtspark,DC=org]
     -g GROUP_QUERY, --group-query=GROUP_QUERY
                           The query/filter used to identify group objects.
-                          [Default: objectClass=group]
+                          [Example: objectClass=group] [Default:
+                          objectClass=group]
+    -k GROUP_DNS, --known-group-dn=GROUP_DNS
+                          The known group Distinguished Name(s) that will be
+                          used directly as a group. Can be more than 1. When
+                          this option is used, the --group-query will not be
+                          used for searching. Useful if your LDAP server
+                          contains a lot of groups. [Example: CN=Release Manager
+                          s,OU=Groups,DC=subversion,DC=thoughtspark,DC=org]
     -m GROUP_MEMBER_ATTRIBUTE, --group-member-attribute=GROUP_MEMBER_ATTRIBUTE
                           The attribute of the group object that stores the
-                          group memberships.  [Default: member]
+                          group memberships. [Example: member] [Default: member]
     -u USER_QUERY, --user-query=USER_QUERY
                           The query/filter used to identify user objects.
-                          [Default: objectClass=user]
+                          [Example: objectClass=user] [Default:
+                          objectClass=user]
     -i USERID_ATTRIBUTE, --userid_attribute=USERID_ATTRIBUTE
                           The attribute of the user object that stores the
-                          userid to be used in the authz file.  [Default: cn]
+                          userid to be used in the authz file. [Example: cn]
+                          [Default: cn]
+    -f, --follow-groups   Follow sub-groups, i.e. add members of sub-groups
+                          recursively. Does not mean OU recursive, which is by
+                          design.
     -z AUTHZ_PATH, --authz-path=AUTHZ_PATH
-                          The path to the authz file to update/create
-    -f, --follow-groups   Follow sub-groups
-    -q, --quiet           Suppress logging information
-    -v, --verbose         Give more details during the execution. Overrides -q
+                          The fully-qualified path to the authz file to be
+                          updated/created.
+    -q, --quiet           Do not show logging information, except exit messages.
+    -v, --verbose         Give more details during the execution. Overrides -q .
 
 Anything that has a "[Default:" string in its corresponding documentation is
 "optional" and can usually be omitted when running against most directory

--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -27,7 +27,7 @@ from optparse import OptionParser
 try:
   import ldap
 except ImportError:
-  print("Unable to locate the 'ldap' module.  Please install python-ldap.  " \
+  sys.stderr.write("Unable to locate the 'ldap' module.  Please install python-ldap.  " \
         "(http://python-ldap.sourceforge.net)")
   sys.exit(1)
 
@@ -91,7 +91,7 @@ followgroups = False
 ################################################################################
 
 application_name = "LDAP Groups to Subversion Authz Groups Bridge"
-application_version = "1.1.0"
+application_version = "1.2.0"
 application_description = "The '%s' is a simple script that will query your " \
                           "directory server for group objects and create a " \
                           "representation of those groups in your Subversion " \
@@ -108,7 +108,7 @@ def bind():
 
   ldapobject.bind_s(bind_dn, bind_password)
 
-  if verbose:
+  if verbose and (authz_path != None) and (authz_path != "None"): # print the following line only if the standard output is not the results file (i.e. the authz destination file path is provided by the -z or --authz-path parameter)
     print("Successfully bound to %s..." % url)
 
   return ldapobject
@@ -122,15 +122,15 @@ def search_for_groups(ldapobject):
   result_set = get_ldap_search_resultset(base_dn, group_query, ldapobject)
 
   if (len(result_set) == 0):
-    if verbose:
-      print("The group_query %s did not return any results." % group_query)
+    if verbose or verbose_if_error:
+      sys.stderr.write("The group_query %s did not return any results." % group_query)
     return
 
   for i in range(len(result_set)):
     for entry in result_set[i]:
       groups.append(entry)
 
-  if verbose:
+  if verbose and (authz_path != None) and (authz_path != "None"): # print the following line only if the standard output is not the results file (i.e. the authz destination file path is provided by the -z or --authz-path parameter)
     print("%d groups found." % len(groups))
 
   return groups
@@ -148,11 +148,11 @@ def get_groups(ldapobject):
         for entry in result_set[i]:
           groups.append(entry)
     except ldap.NO_SUCH_OBJECT, e:
-      if verbose:
-        print("Couldn't find a group with DN %s." % group_dn)
+      if verbose or verbose_if_error:
+        sys.stderr.write("Couldn't find a group with DN %s." % group_dn)
       raise e
 
-  if verbose:
+  if verbose and (authz_path != None) and (authz_path != "None"): # print the following line only if the standard output is not the results file (i.e. the authz destination file path is provided by the -z or --authz-path parameter)
     print("%d groups found." % len(groups))
 
   return groups
@@ -199,8 +199,8 @@ def get_members_from_group(group, ldapobject):
             sys.stderr.write(".")
           members.append(str.lower(attrs[userid_attribute][0]))
         else:
-          if verbose:
-            print("[WARNING]: %s does not have the %s attribute..." \
+          if verbose or verbose_if_error:
+            sys.stderr.write("[WARNING]: %s does not have the %s attribute..." \
                   % (user[0][0][0], userid_attribute))
       else:
         # Check to see if this member is really a group
@@ -217,14 +217,14 @@ def get_members_from_group(group, ldapobject):
             try:
               members.append("GROUP:" + mg[0][0][0])
             except TypeError:
-              print("[WARNING]: TypeError with %s..." % mg[0])
+              sys.stderr.write("[WARNING]: TypeError with %s..." % mg[0])
         else:
-          if verbose:
-            print("[WARNING]: %s is a member of %s but is neither a group " \
+          if verbose or verbose_if_error:
+            sys.stderr.write("[WARNING]: %s is a member of %s but is neither a group " \
                   "nor a user." % (member, group['cn'][0]))
     except ldap.LDAPError, error_message:
-      if verbose:
-        print("[WARNING]: %s object was not found..." % member)
+      if verbose or verbose_if_error:
+        sys.stderr.write("[WARNING]: %s object was not found..." % member)
   # uniq values
   members = list(set(members))
   if verbose:
@@ -381,10 +381,10 @@ def print_group_model(groups, memberships):
           if groupkey:
             user = "@" + groupkey
           else:
-            print("[WARNING]: subgroup not in search scope: %s. This means " %
-                   memberships[i][j].replace("GROUP:","") +
-                  "you won't have all members in the SVN group: %s." % 
-                   short_name)
+            sys.stderr.write("[WARNING]: subgroup not in search scope: %s. This means " %
+                              memberships[i][j].replace("GROUP:","") +
+                             "you won't have all members in the SVN group: %s." % 
+                              short_name)
         else:
           user = memberships[i][j]
 
@@ -455,6 +455,7 @@ def load_cli_properties(parser):
   global userid_attribute
   global authz_path
   global verbose
+  global verbose_if_error
   global followgroups
 
   (options, args) = parser.parse_args(args=None, values=None)
@@ -470,6 +471,7 @@ def load_cli_properties(parser):
   userid_attribute = options.userid_attribute
   authz_path = options.authz_path
   verbose = options.verbose
+  verbose_if_error = options.verbose_if_error
   followgroups = options.followgroups
 
 # load_cli_properties()
@@ -516,6 +518,10 @@ def create_cli_parser():
                     help="The path to the authz file to update/create")
   parser.add_option("-q", "--quiet", action="store_false", dest="verbose",
                     default=True, help="Suppress logging information")
+  parser.add_option("-v", "--verbose-if-error", action="store_true",
+                    dest="verbose_if_error", default=False,
+                    help="Be verbose only for errors or warnings. " \
+                         "This option is active only with -q.")
 
   return parser
 
@@ -580,12 +586,12 @@ def main():
     load_cli_properties(parser)
 
   if not are_properties_set():
-    print("There is not enough information to proceed.")
+    sys.stderr.write("There is not enough information to proceed.")
     
     for prop in get_unset_properties():
-      print("'%s' was not passed" % prop)
+      sys.stderr.write("'%s' was not passed" % prop)
 
-    print("")
+    sys.stderr.write("")
     parser.print_help()
     parser.exit()
 
@@ -602,7 +608,7 @@ def main():
   try:
     ldapobject = bind()
   except ldap.LDAPError, error_message:
-    print("Could not connect to %s. Error: %s " % (url, error_message))
+    sys.stderr.write("Could not connect to %s. Error: %s " % (url, error_message))
     sys.exit(1)
 
   try:    
@@ -611,17 +617,17 @@ def main():
     else:
       groups = search_for_groups(ldapobject)
   except ldap.LDAPError, error_message:
-    print("Error performing search: %s " % error_message)
+    sys.stderr.write("Error performing search: %s " % error_message)
     sys.exit(1)
 
   if groups and len(groups) == 0:
-    print("There were no groups found with the group_query / group_dns you supplied.")
-    sys.exit(0)
+    sys.stderr.write("There were no groups found with the group_query / group_dns you supplied.")
+    sys.exit(1)
 
   try:
     memberships = create_group_model(groups, ldapobject)[1]
   except ldap.LDAPError, error_message:
-    print("Error creating group model: %s" % error_message)
+    sys.stderr.write("Error creating group model: %s" % error_message)
     sys.exit(1)
 
   print_group_model(groups, memberships)

--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -68,17 +68,25 @@ except ImportError:
 # This is the fully-qualified path to the authz file to write to.
 #authz_path = "/opt/svn/svn_authz.txt"
 
+# Add members of sub-groups recursively
+# does not mean OU recursive (which is by design)
+#followgroups = False
+
 ################################################################################
 # Runtime Options
 # uncomment if you want to use them instead of the command line parameters
 ################################################################################
 
-# This indicates whether or not to output logging information
-#verbose = True
+# Keep the exact LDAP group names without alteration.
+# Useful if your group names contain non-word characters, i.e. not in [A-Za-z0-9_].
+#keep_names = False
 
-# Add members of sub-groups recursively
-# does not mean OU recursive (which is by design)
-#followgroups = False
+# Do not show logging information, except exit messages.
+#silent = False
+
+# This indicates whether or not to give more details during the execution.
+# Overrides -q .
+#verbose = True
 
 ################################################################################
 # Application Settings
@@ -307,7 +315,7 @@ def create_group_map(groups):
 
 def simplify_name(name):
   """Creates an authz simple group name."""
-  return re.sub("\W", "", name)
+  return name if (keep_names) else re.sub("\W", "", name)
 
 # simplify_name()
 
@@ -473,8 +481,9 @@ def load_cli_properties(parser):
   global group_member_attribute
   global user_query
   global userid_attribute
-  global authz_path
   global followgroups
+  global authz_path
+  global keep_names
   global silent
   global verbose
   
@@ -491,8 +500,9 @@ def load_cli_properties(parser):
   group_member_attribute = options.group_member_attribute
   user_query = options.user_query
   userid_attribute = options.userid_attribute
-  authz_path = options.authz_path
   followgroups = options.followgroups
+  authz_path = options.authz_path
+  keep_names = options.keep_names
   silent = options.silent
   verbose = options.verbose
   
@@ -556,6 +566,11 @@ def create_cli_parser():
                          "recursively. Does not mean OU recursive, which is by design.")
   parser.add_option("-z", "--authz-path", dest="authz_path",
                     help="The fully-qualified path to the authz file to be updated/created.")
+  parser.add_option("-n", "--keep-names", action="store_true",
+                    dest="keep_names", default=False,
+                    help="Keep the exact LDAP group names without alteration. " \
+                         "Useful if your group names contain non-word " \
+                         "characters, i.e. not in [A-Za-z0-9_].")
   parser.add_option("-q", "--quiet", action="store_true",
                     dest="silent", default=False,
                     help="Do not show logging information, except exit messages.")

--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -91,7 +91,7 @@ followgroups = False
 ################################################################################
 
 application_name = "LDAP Groups to Subversion Authz Groups Bridge"
-application_version = "1.2.0"
+application_version = "1.3.0"
 application_description = "The '%s' is a simple script that will query your " \
                           "directory server for group objects and create a " \
                           "representation of those groups in your Subversion " \

--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -27,56 +27,50 @@ from optparse import OptionParser
 try:
   import ldap
 except ImportError:
-  sys.stderr.write("Unable to locate the 'ldap' module.  Please install python-ldap.  " \
-        "(http://python-ldap.sourceforge.net)")
+  sys.stderr.write("Unable to locate the 'ldap' module. Please install python-ldap. " \
+                   "(http://python-ldap.sourceforge.net)\n")
   sys.exit(1)
 
 ################################################################################
 # Configuration Options
+# uncomment if you want to use them instead of the command line parameters
 ################################################################################
 
 # This is the distinguished name used to bind to the LDAP server.
-# [Example: CN=Jeremy Whitlock,OU=Users,DC=subversion,DC=thoughtspark,DC=org]
-bind_dn = None
+#bind_dn = "CN=Jeremy Whitlock,OU=Users,DC=subversion,DC=thoughtspark,DC=org"
 
 # This is the password for the user connecting to the LDAP server.
-# [Example: pa55w0rd]
-bind_password = None
+#bind_password = "pa55w0rd"
 
 # This is the fully-qualified url to the LDAP server.
-# [Example: ldap://localhost:389]
-url = None
+#url = "ldap://localhost:389"
 
 # This is the distinguished name to where the group search will start.
-# [Example: DC=subversion,DC=thoughtspark,DC=org]
-base_dn = None
+#base_dn = "DC=subversion,DC=thoughtspark,DC=org"
 
 # This is the query/filter used to identify group objects.
-# [Example: objectClass=group]
-group_query = "objectClass=group"
+#group_query = "objectClass=group"
 
 # This is the known group DNs that will be used directly as a group
-# [Example: CN=Release Managers,OU=Groups,DC=subversion,DC=thoughtspark,DC=org]
-group_dns = []
+# Default: group_dns = []
+#group_dns = "CN=Release Managers,OU=Groups,DC=subversion,DC=thoughtspark,DC=org"
 
 # This is the attribute of the group object that stores the group memberships.
-# [Example: member]
-group_member_attribute = "member"
+#group_member_attribute = "member"
 
 # This is the query/filter used to identify user objects.
-# [Example: objectClass=user]
-user_query = "objectClass=user"
+#user_query = "objectClass=user"
 
 # This is the attribute of the user object that stores the userid to be used in
-# the authz file.  [Example: cn]
-userid_attribute = "cn"
+# the authz file.
+#userid_attribute = "cn"
 
 # This is the fully-qualified path to the authz file to write to.
-# [Example: /opt/svn/svn_authz.txt]
-authz_path = None
+#authz_path = "/opt/svn/svn_authz.txt"
 
 ################################################################################
 # Runtime Options
+# uncomment if you want to use them instead of the command line parameters
 ################################################################################
 
 # This indicates whether or not to output logging information
@@ -110,9 +104,9 @@ def bind():
 
   if verbose:
     if is_outfile_specified:
-      print("Successfully bound to %s..." % url)
+      sys.stdout.write("Successfully bound to %s...\n" % url)
     else:
-      sys.stderr.write("Successfully bound to %s..." % url)
+      sys.stderr.write("Successfully bound to %s...\n" % url)
 
   return ldapobject
 
@@ -126,7 +120,7 @@ def search_for_groups(ldapobject):
 
   if (len(result_set) == 0):
     if not silent:
-      sys.stderr.write("The group_query %s did not return any results." % group_query)
+      sys.stderr.write("The group_query %s did not return any results.\n" % group_query)
     return
 
   for i in range(len(result_set)):
@@ -135,9 +129,9 @@ def search_for_groups(ldapobject):
 
   if verbose:
     if is_outfile_specified:
-      print("%d groups found." % len(groups))
+      sys.stdout.write("%d groups found.\n" % len(groups))
     else:
-      sys.stderr.write("%d groups found." % len(groups))
+      sys.stderr.write("%d groups found.\n" % len(groups))
 
   return groups
 
@@ -155,14 +149,14 @@ def get_groups(ldapobject):
           groups.append(entry)
     except ldap.NO_SUCH_OBJECT, e:
       if not silent:
-        sys.stderr.write("Couldn't find a group with DN %s." % group_dn)
+        sys.stderr.write("Couldn't find a group with DN %s.\n" % group_dn)
       raise e
 
   if verbose:
     if is_outfile_specified:
-      print("%d groups found." % len(groups))
+      sys.stdout.write("%d groups found.\n" % len(groups))
     else:
-      sys.stderr.write("%d groups found." % len(groups))
+      sys.stderr.write("%d groups found.\n" % len(groups))
 
   return groups
 
@@ -191,7 +185,7 @@ def get_members_from_group(group, ldapobject):
   group_members = []
   if verbose:
     if is_outfile_specified:
-      print("+")
+      sys.stdout.write("+")
     else:
       sys.stderr.write("+")
   if group.has_key(group_member_attribute):
@@ -209,13 +203,13 @@ def get_members_from_group(group, ldapobject):
         if (attrs.has_key(userid_attribute)):
           if verbose:
             if is_outfile_specified:
-              print(".")
+              sys.stdout.write(".")
             else:
               sys.stderr.write(".")
           members.append(str.lower(attrs[userid_attribute][0]))
         else:
           if not silent:
-            sys.stderr.write("[WARNING]: %s does not have the %s attribute..." \
+            sys.stderr.write("[WARNING]: %s does not have the %s attribute...\n" \
                               % (user[0][0][0], userid_attribute))
       else:
         # Check to see if this member is really a group
@@ -233,19 +227,19 @@ def get_members_from_group(group, ldapobject):
               members.append("GROUP:" + mg[0][0][0])
             except TypeError:
               if not silent:
-                sys.stderr.write("[WARNING]: TypeError with %s..." % mg[0])
+                sys.stderr.write("[WARNING]: TypeError with %s...\n" % mg[0])
         else:
           if not silent:
             sys.stderr.write("[WARNING]: %s is a member of %s but is neither a group " \
-                             "nor a user." % (member, group['cn'][0]))
+                             "nor a user.\n" % (member, group['cn'][0]))
     except ldap.LDAPError, error_message:
       if not silent:
-        sys.stderr.write("[WARNING]: %s object was not found..." % member)
+        sys.stderr.write("[WARNING]: %s object was not found...\n" % member)
   # uniq values
   members = list(set(members))
   if verbose:
     if is_outfile_specified:
-      print("-")
+      sys.stdout.write("-")
     else:
       sys.stderr.write("-")
   return members
@@ -261,14 +255,14 @@ and will create a group membership model for each group."""
     for group in groups:
       if verbose:
         if is_outfile_specified:
-          print("[INFO]: Processing group %s: " % group[1]['cn'][0])
+          sys.stdout.write("[INFO]: Processing group %s: " % group[1]['cn'][0])
         else:
           sys.stderr.write("[INFO]: Processing group %s: " % group[1]['cn'][0])
       members = get_members_from_group(group[1], ldapobject)
       memberships.append(members)
       if verbose:
         if is_outfile_specified:
-          print("\n")
+          sys.stdout.write("\n")
         else:
           sys.stderr.write("\n")
 
@@ -409,7 +403,7 @@ def print_group_model(groups, memberships):
             if not silent:
               sys.stderr.write("[WARNING]: subgroup not in search scope: %s. This means " %
                                 memberships[i][j].replace("GROUP:","") +
-                               "you won't have all members in the SVN group: %s." % 
+                               "you won't have all members in the SVN group: %s.\n" % 
                                 short_name)
         else:
           user = memberships[i][j]
@@ -437,7 +431,7 @@ def print_group_model(groups, memberships):
     tmpfile = open(tmp_authz_path, 'r')
 
     for line in tmpfile.readlines():
-      print(line)
+      sys.stdout.write(line)
 
     tmpfile.close()
 
@@ -512,45 +506,62 @@ def create_cli_parser():
   parser = OptionParser(usage=usage, description=application_description)
 
   parser.add_option("-d", "--bind-dn", dest="bind_dn",
-                    help="The DN of the user to bind to the directory with")
+                    help="The Distinguished Name (DN) used to bind to the " \
+                         "directory with. " \
+                         "[Example: CN=Jeremy Whitlock,OU=Users," \
+                         "DC=subversion,DC=thoughtspark,DC=org]")
   parser.add_option("-p", "--bind-password", dest="bind_password",
-                    help="The password for the user specified with the " \
-                         "--bind-dn")
+                    help="The password for the user specified with the --bind-dn . " \
+                         "[Example: pa55w0rd]")
   parser.add_option("-l", "--url", dest="url",
-                    help="The url (scheme://hostname:port) for the directory " \
-                         "server")
+                    help="The fully-qualified URL (scheme://hostname:port) to " \
+                         "the directory server. " \
+                         "[Example: ldap://localhost:389]")
   parser.add_option("-b", "--base-dn", dest="base_dn",
-                    help="The DN at which to perform the recursive search")
+                    help="The Distinguished Name (DN) at which the recursive " \
+                         "group search will start. " \
+                         "[Example: DC=subversion,DC=thoughtspark,DC=org]")
   parser.add_option("-g", "--group-query", dest="group_query",
                     default="objectClass=group",
                     help="The query/filter used to identify group objects. " \
+                         "[Example: objectClass=group] " \
                          "[Default: %default]")
   parser.add_option("-k", "--known-group-dn", action="append", dest="group_dns",
-                    help="The known group DN. Can be more than 1. When this option is used, the " \
-                         "--group-query will not be used for searching. Use this if " \
-                         "your LDAP server contains a lot of groups.")
+                    help="The known group Distinguished Name(s) that will be used " \
+                         "directly as a group. Can be more than 1. When this option is " \
+                         "used, the --group-query will not be used for searching. " \
+                         "Useful if your LDAP server contains a lot of groups. " \
+                         "[Example: CN=Release Managers,OU=Groups," \
+                         "DC=subversion,DC=thoughtspark,DC=org]")
   parser.add_option("-m", "--group-member-attribute",
                     dest="group_member_attribute", default="member",
                     help="The attribute of the group object that stores the " \
-                         "group memberships.  [Default: %default]")
+                         "group memberships. " \
+                         "[Example: member] " \
+                         "[Default: %default]")
   parser.add_option("-u", "--user-query", dest="user_query",
                     default="objectClass=user",
                     help="The query/filter used to identify user objects. " \
+                         "[Example: objectClass=user] " \
                          "[Default: %default]")
   parser.add_option("-i", "--userid_attribute", dest="userid_attribute",
                     default="cn",
                     help="The attribute of the user object that stores the " \
-                         "userid to be used in the authz file.  " \
+                         "userid to be used in the authz file. " \
+                         "[Example: cn] " \
                          "[Default: %default]")
-  parser.add_option("-f", "--follow-groups", action="store_true", dest="followgroups",
-                    default=False, help="Follow sub-groups")
+  parser.add_option("-f", "--follow-groups", action="store_true",
+                    dest="followgroups", default=False,
+                    help="Follow sub-groups, i.e. add members of sub-groups " \
+                         "recursively. Does not mean OU recursive, which is by design.")
   parser.add_option("-z", "--authz-path", dest="authz_path",
-                    help="The path to the authz file to update/create")
-  parser.add_option("-q", "--quiet", action="store_true", dest="silent",
-                    default=False, help="Do not show logging information except exit messages.")
-  parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
-                    default=False, help="Give more details during the execution. " \
-                                        "Overrides -q")
+                    help="The fully-qualified path to the authz file to be updated/created.")
+  parser.add_option("-q", "--quiet", action="store_true",
+                    dest="silent", default=False,
+                    help="Do not show logging information, except exit messages.")
+  parser.add_option("-v", "--verbose", action="store_true",
+                    dest="verbose", default=False,
+                    help="Give more details during the execution. Overrides -q .")
 
   return parser
 
@@ -559,19 +570,23 @@ def create_cli_parser():
 def are_properties_set():
   """This function will perform a simple test to make sure none of the
 properties are 'None'."""
-  if (bind_dn == None):
-    return False
-  if (url == None):
-    return False
-  if (base_dn == None):
-    return False
-  if (group_query == None):
-    return False
-  if (group_member_attribute == None):
-    return False
-  if (user_query == None):
-    return False
-  if (userid_attribute == None):
+  try:
+    if (bind_dn == None):
+      return False
+    if (url == None):
+      return False
+    if (base_dn == None):
+      return False
+    if (group_query == None):
+      return False
+    if (group_member_attribute == None):
+      return False
+    if (user_query == None):
+      return False
+    if (userid_attribute == None):
+      return False
+  except:
+    # one of the variables may not exist (i.e. not defined at the start of the script)
     return False
   
   # bind_password is not checked since if not passed, the user will be prompted
@@ -606,23 +621,27 @@ def get_unset_properties():
 
 def main():
   """This function is the entry point for this script."""
+  
+  parser = None
 
-  # Create the OptionParser
-  parser = create_cli_parser()
-
-  # Attempt to load properties from the command line if necessary
+  # If all necessary options are not properly set in the current script file
+  # (see at the top of the script)
   if not are_properties_set():
+    # Attempt to load them from the command line parameters
+    parser = create_cli_parser()
     load_cli_properties(parser)
 
+  # if some properties are not set at this point, there is an error
   if not are_properties_set():
-    sys.stderr.write("There is not enough information to proceed.")
+    sys.stderr.write("There is not enough information to proceed.\n")
     
     for prop in get_unset_properties():
-      sys.stderr.write("'%s' was not passed" % prop)
+      sys.stderr.write("'%s' was not passed\n" % prop)
 
-    sys.stderr.write("")
-    parser.print_help()
-    parser.exit()
+    sys.stderr.write("\n")
+    if parser != None:
+      parser.print_help()
+      parser.exit()
 
   # Allow user to type in password if missing
   global bind_password
@@ -637,7 +656,7 @@ def main():
   try:
     ldapobject = bind()
   except ldap.LDAPError, error_message:
-    sys.stderr.write("Could not connect to %s. Error: %s " % (url, error_message))
+    sys.stderr.write("Could not connect to %s. Error: %s \n" % (url, error_message))
     sys.exit(1)
 
   try:    
@@ -646,17 +665,18 @@ def main():
     else:
       groups = search_for_groups(ldapobject)
   except ldap.LDAPError, error_message:
-    sys.stderr.write("Error performing search: %s " % error_message)
+    sys.stderr.write("Error performing search: %s \n" % error_message)
     sys.exit(1)
 
   if groups and len(groups) == 0:
-    sys.stderr.write("There were no groups found with the group_query / group_dns you supplied.")
+    sys.stderr.write("There were no groups found with the group_query / group_dns " \
+                     "you supplied.\n")
     sys.exit(1)
 
   try:
     memberships = create_group_model(groups, ldapobject)[1]
   except ldap.LDAPError, error_message:
-    sys.stderr.write("Error creating group model: %s" % error_message)
+    sys.stderr.write("Error creating group model: %s\n" % error_message)
     sys.exit(1)
 
   print_group_model(groups, memberships)


### PR DESCRIPTION
- Better management of outputs: all errors/warnings are directed to stderr; info messages are given to stdout if an authz destination file is provided and are redirected to stderr otherwise.
- New parameter -v to distinguish warning/error and info verbosity (-v enables info logs; -q disables warning/error logs).
- Exit with error code 1 when no group is found.
- Hard-coded parameters at the top of the script are now optional.
- New parameter -n to keep exact LDAP group names. For example, "my-group" is no longer replaced by "mygroup".
- All text found "around" the auto-generated groups are now restored at the right place. You can define supergroups from LDAP groups safely.
